### PR TITLE
fix conversion of md links containing anchors to html

### DIFF
--- a/vimwiki_markdown.py
+++ b/vimwiki_markdown.py
@@ -31,7 +31,6 @@ default_template = """<!DOCTYPE html>
 </html>
 """
 default_extension = ["fenced_code", "tables", "codehilite", "toc"]
-anchor_duplicates = {}
 
 vim = shutil.which("vim") and "vim" or (shutil.which("nvim") and "nvim")
 
@@ -58,7 +57,6 @@ class LinkInlineProcessor(markdown.inlinepatterns.LinkInlineProcessor):
         if not href.startswith("http") and not href.endswith(".html"):
             if auto_index and href.endswith("/"):
                 href += "index.html"
-                print("case 1: ", href)
             # anchor md to html link
             elif anchor_match:
                 hlnk = anchor_match.group(1)
@@ -68,7 +66,6 @@ class LinkInlineProcessor(markdown.inlinepatterns.LinkInlineProcessor):
                 href = hlnk + ".html#" + anchor
             elif not href.endswith("/"):
                 href += ".html"
-                print("case 3: ", href)
         return href, title, index, handled
 
 

--- a/vimwiki_markdown.py
+++ b/vimwiki_markdown.py
@@ -8,7 +8,7 @@ import subprocess
 import sys
 import markdown
 
-from re import search, sub
+from re import search
 
 
 default_template = """<!DOCTYPE html>
@@ -55,41 +55,20 @@ class LinkInlineProcessor(markdown.inlinepatterns.LinkInlineProcessor):
         # regex match for anchor hrefs
         anchor_pattern = r'(.+)#(.+)'
         anchor_match = search(anchor_pattern, href)
-        # regex match for anchor duplicates
-        anchor_dup_pattern = r"(.+)_(\d+$)"
         if not href.startswith("http") and not href.endswith(".html"):
             if auto_index and href.endswith("/"):
                 href += "index.html"
+                print("case 1: ", href)
             # anchor md to html link
             elif anchor_match:
                 hlnk = anchor_match.group(1)
                 # slugify md anchors to make them match href ids
                 anchor = markdown.extensions.toc.slugify(anchor_match.group(2),
                                                          "-")
-                # regex match for anchor duplicates
-                anchor_dup_match = search(anchor_dup_pattern, anchor)
-                # new match which happens to be using "_\d+$"
-                if anchor_dup_match and (anchor not in
-                                         anchor_duplicates.keys()):
-                    anchor_duplicates[anchor] = 1
-                # match for a known duplicate anchor
-                elif anchor_dup_match:
-                    anchor_duplicates[anchor_dup_match.group(0)] += 1
-                    anchor = sub(r"\d+$",
-                                 str(int(anchor_dup_match.group(2)) + 1),
-                                 anchor)
-                    anchor_duplicates[anchor] = 1
-                # match which creates a duplicate anchor
-                elif anchor in anchor_duplicates.keys():
-                    anchor_duplicates[anchor] += 1
-                    anchor += f"_{anchor_duplicates[anchor] - 1}"
-                    anchor_duplicates[anchor] = 1
-                # new anchor
-                else:
-                    anchor_duplicates[anchor] = 1
                 href = hlnk + ".html#" + anchor
             elif not href.endswith("/"):
                 href += ".html"
+                print("case 3: ", href)
         return href, title, index, handled
 
 

--- a/vimwiki_markdown.py
+++ b/vimwiki_markdown.py
@@ -6,8 +6,10 @@ import os
 import shutil
 import subprocess
 import sys
-
 import markdown
+
+from re import search
+
 
 default_template = """<!DOCTYPE html>
 <html>
@@ -49,16 +51,24 @@ class LinkInlineProcessor(markdown.inlinepatterns.LinkInlineProcessor):
 
     def getLink(self, *args, **kwargs):
         href, title, index, handled = super().getLink(*args, **kwargs)
+        # regex match for anchor hrefs
+        anchor_pattern = r'(.+)#(.+)'
+        match = search(anchor_pattern, href)
         if not href.startswith("http") and not href.endswith(".html"):
             if auto_index and href.endswith("/"):
                 href += "index.html"
+            # anchor md to html link
+            elif match:
+                hlnk = match.group(1)
+                anchor = match.group(2)
+                href = hlnk + ".html#" + anchor
             elif not href.endswith("/"):
                 href += ".html"
         return href, title, index, handled
 
 
-def get(l, index, default):
-    return l[index] if index < len(l) else default
+def get(l_, index, default):
+    return l_[index] if index < len(l_) else default
 
 
 def main():
@@ -154,7 +164,8 @@ def main():
         # Parse template
         for placeholder, value in placeholders.items():
             template = template.replace(placeholder, value)
-        # use blank insted of os.getcwd() because - mean in root directory that contain css
+        # use blank insted of os.getcwd() because - mean in root directory that
+        # contain css
         template = template.replace(
             "%root_path%", ROOT_PATH if ROOT_PATH != "-" else ""
         )


### PR DESCRIPTION
# Issue
When converting (from `.md` in this case) to `.html`, using
[WnP/vimwiki_markdown](https://github.com/WnP/vimwiki_markdown), the hyperlink
paths with anchors resolve to e.g.: 

`file:///path/to/vimwiki/vimwiki_html/index#foo.html`

instead of the expected:

`file:///path/to/vimwiki/vimwiki_html/index.html#foo`

this causes hyperlinks with anchors to not be followed, when navigating the
`.hmtl` files.

## Steps to reproduce the issue
On a new wiki...

1. Create `foo.md`, with content:
```markdown
# anchor1

## anchor2

### anchor3
```

2. Create `bar.md`, with content:
```markdown
[anchor3](path/to/foo#anchor3)
```

3. Run `:Vimwiki2HTML` to convert the files to .html;

4. Open `bar.html` and inspect the `[anchor3]` hyperlink.

# Pull Request

## Proposal
This PR offers a solution for vimwiki/vimwiki#1260.

It integrates with the Python `markdown` library directly, through the
[Table of Contents extension](https://python-markdown.github.io/extensions/toc/#usage),
which provides access to header ids.

## Implementation
* fix conversion of md links containing anchors to html
        * use `re.search` to match anchors (#) in hrefs
        * split the match into two groups
	        * G1: hyperlink
        	* G2: anchor
        * rearrange groups with `.html` extension

* implement anchor link following in html
        * access markdown TOC extension
        * slugify md anchors to make them href id friendly

## Caveats
Using anchor names which mimic html href ids of duplicate anchors is discouraged i.e., those:
* terminating with underscores and followed by numeric digits (e.g. `foo#bar_69` may increment to `foo#bar_70`)
* with more than one dash in a row (e.g. `foo#bar-- ---- ---- --69` may collapse to `foo#bar-69`)

Thank you very much for developing WnP/vimwiki_markdown. 
