### PR TITLE
Manage URLs with urllib

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ are activated by default:
 - [fenced_code](https://python-markdown.github.io/extensions/fenced_code_blocks/)
 - [tables](https://python-markdown.github.io/extensions/tables/)
 - [CodeHilite](https://python-markdown.github.io/extensions/code_hilite/)
+- [Table of Contents](https://python-markdown.github.io/extensions/toc/)
 
 But you can add more extensions using `VIMWIKI_MARKDOWN_EXTENSIONS` environment variable:
 1. Json dictionary syntax of extension with configuration

--- a/vimwiki_markdown.py
+++ b/vimwiki_markdown.py
@@ -6,10 +6,8 @@ import os
 import shutil
 import subprocess
 import sys
+
 import markdown
-
-from re import search
-
 
 default_template = """<!DOCTYPE html>
 <html>
@@ -30,7 +28,7 @@ default_template = """<!DOCTYPE html>
     </body>
 </html>
 """
-default_extension = ["fenced_code", "tables", "codehilite", "toc"]
+default_extension = ["fenced_code", "tables", "codehilite"]
 
 vim = shutil.which("vim") and "vim" or (shutil.which("nvim") and "nvim")
 
@@ -51,26 +49,16 @@ class LinkInlineProcessor(markdown.inlinepatterns.LinkInlineProcessor):
 
     def getLink(self, *args, **kwargs):
         href, title, index, handled = super().getLink(*args, **kwargs)
-        # regex match for anchor hrefs
-        anchor_pattern = r'(.+)#(.+)'
-        anchor_match = search(anchor_pattern, href)
         if not href.startswith("http") and not href.endswith(".html"):
             if auto_index and href.endswith("/"):
                 href += "index.html"
-            # anchor md to html link
-            elif anchor_match:
-                hlnk = anchor_match.group(1)
-                # slugify md anchors to make them match href ids
-                anchor = markdown.extensions.toc.slugify(anchor_match.group(2),
-                                                         "-")
-                href = hlnk + ".html#" + anchor
             elif not href.endswith("/"):
                 href += ".html"
         return href, title, index, handled
 
 
-def get(l_, index, default):
-    return l_[index] if index < len(l_) else default
+def get(l, index, default):
+    return l[index] if index < len(l) else default
 
 
 def main():
@@ -166,8 +154,7 @@ def main():
         # Parse template
         for placeholder, value in placeholders.items():
             template = template.replace(placeholder, value)
-        # use blank insted of os.getcwd() because - mean in root directory that
-        # contain css
+        # use blank insted of os.getcwd() because - mean in root directory that contain css
         template = template.replace(
             "%root_path%", ROOT_PATH if ROOT_PATH != "-" else ""
         )

--- a/vimwiki_markdown.py
+++ b/vimwiki_markdown.py
@@ -9,6 +9,8 @@ import sys
 
 import markdown
 
+from urllib.parse import urlparse
+
 default_template = """<!DOCTYPE html>
 <html>
     <head>
@@ -28,7 +30,7 @@ default_template = """<!DOCTYPE html>
     </body>
 </html>
 """
-default_extension = ["fenced_code", "tables", "codehilite"]
+default_extension = ["fenced_code", "tables", "codehilite", "toc"]
 
 vim = shutil.which("vim") and "vim" or (shutil.which("nvim") and "nvim")
 
@@ -49,10 +51,11 @@ class LinkInlineProcessor(markdown.inlinepatterns.LinkInlineProcessor):
 
     def getLink(self, *args, **kwargs):
         href, title, index, handled = super().getLink(*args, **kwargs)
-        if not href.startswith("http") and not href.endswith(".html"):
+        url = urlparse(href)
+        if not url.scheme.startswith("http") and not url.path.endswith(".html"):
             if auto_index and href.endswith("/"):
                 href += "index.html"
-            elif not href.endswith("/"):
+            elif not href.endswith("/") and not url.fragment:
                 href += ".html"
         return href, title, index, handled
 


### PR DESCRIPTION
This is an alternative implementation of #23 and #25, using [urllib](https://docs.python.org/3/library/urllib.parse.html) to parse URLs.

This also adds [Table of Contents](https://python-markdown.github.io/extensions/toc/) markdown extension in the default extensions.

FYI: @joaoandreporto @jreichert 