### PR TITLE
✨ (vimwiki_markdown.py): Convert task list markers to unicode symbols

### DIFF
--- a/vimwiki_markdown.py
+++ b/vimwiki_markdown.py
@@ -31,7 +31,7 @@ default_template = """<!DOCTYPE html>
     </body>
 </html>
 """
-default_extension = ["fenced_code", "tables", "codehilite", "toc"]
+default_extension = ["fenced_code", "tables", "codehilite", "toc", "smarty"]
 
 vim = shutil.which("vim") and "vim" or (shutil.which("nvim") and "nvim")
 

--- a/vimwiki_markdown.py
+++ b/vimwiki_markdown.py
@@ -3,6 +3,7 @@
 import datetime
 import json
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -62,6 +63,17 @@ class LinkInlineProcessor(markdown.inlinepatterns.LinkInlineProcessor):
 
 def get(l, index, default):
     return l[index] if index < len(l) else default
+
+
+def convert_task_lists(html):
+    """Convert GitHub-style task list markers to unicode symbols in HTML list items."""
+    # Pattern for checked items: <li> followed by optional whitespace,
+    # [x] or [X], followed by optional whitespace
+    html = re.sub(r'(<li>)\s*\[(x|X)\]\s*', r'\1☑ ', html)
+    # Pattern for unchecked items: <li> followed by optional whitespace,
+    # [ ] followed by optional whitespace
+    html = re.sub(r'(<li>)\s*\[ \]\s*', r'\1☐ ', html)
+    return html
 
 
 def main():
@@ -164,6 +176,9 @@ def main():
 
         # Parse content
         content = md.convert(content)
+
+        # Convert task list markers to unicode symbols
+        content = convert_task_lists(content)
 
         # Merge template
         template = template.replace("%content%", content)


### PR DESCRIPTION
- Add convert_task_lists() function to transform [ ], [x], [X] in list items to ☐ and ☑ unicode symbols respectively
- Process HTML output after markdown conversion
- Supports both * and - list markers

Generated by Mistral Vibe.